### PR TITLE
Replace README with the license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
+## Terms of Use
+
 <a rel="license" href="http://creativecommons.org/licenses/by-nd/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nd/4.0/88x31.png" /></a><br />All assets in this repository are licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nd/4.0/">Creative Commons Attribution-NoDerivatives 4.0 International License</a>.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,1 @@
-# Conditions of Use
-Any the assets contained in this repository are distributed freely with the given terms.
-
-When used in still formats (such as an image overlay) any 'asset' of 'Off the Dial' and/or it's tournaments **may not** be altered in the following ways:
-- Have its proportions changed
-- Changed text fonts or sizing
-- Altered the symbols and shapes present on the 'asset'
-- Any modifications, additions or subtractions that misrepresents Off the Dial in a negative, inappropriate, derogatory or racist manner.
-- Any subtractions from the logo
-- Any additions to the logo that intentionally covers up parts of the logo
-
-When used in moving formats (such as a video or moving gif) any 'asset' of 'Off the Dial' and/or it's tournaments may be altered in the following ways:
-- Separate parts of the logo may be moved (such as the dial, octo and phone)
-
-An 'asset' refers to any image, logo, banner, video, stinger, animation created for the purpose of Off the Dial or its tournaments.
-
-### These assets can not be used for commercial use
-*Note: This doesn't include if you're advertising/thumbnails for your own stream/video where you're playing in an Off the Dial event. 3rd party promotion for Off the Dial is also excluded from this.*
+<a rel="license" href="http://creativecommons.org/licenses/by-nd/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nd/4.0/88x31.png" /></a><br />All assets in this repository are licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nd/4.0/">Creative Commons Attribution-NoDerivatives 4.0 International License</a>.


### PR DESCRIPTION
The current terms of use are confusing and not very well standardized.

Instead, replace the terms of use with a standardized creative commons license.

I chose the NoDerivatives license as it seems the most applicable. The gist is:

**Allow:**
- Share, including for commercial (advertizing) use.

**Conditions:**
- Give credit
- No modification